### PR TITLE
Implement core functionality for AHB Sales app with language support

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,7 +10,30 @@
     "plugin:@typescript-eslint/recommended",
     "plugin:import/recommended",
     "plugin:import/electron",
-    "plugin:import/typescript"
+    "plugin:import/typescript",
+    "plugin:vue/vue3-recommended"
   ],
-  "parser": "@typescript-eslint/parser"
+  "parser": "vue-eslint-parser",
+  "parserOptions": {
+    "parser": "@typescript-eslint/parser",
+    "ecmaVersion": 2020,
+    "sourceType": "module",
+    "extraFileExtensions": [".vue"]
+  },
+  "settings": {
+    "import/resolver": {
+      "typescript": true,
+      "node": { "extensions": [".js", ".jsx", ".ts", ".tsx", ".d.ts", ".vue"] }
+    }
+  },
+  "overrides": [
+    {
+      "files": ["*.vue"],
+      "rules": {
+        "@typescript-eslint/no-explicit-any": "off",
+        "import/no-unresolved": "off"
+      }
+    },
+    { "files": ["src/index.css"], "rules": {} }
+  ]
 }

--- a/.tmp-userData-tests/settings.json
+++ b/.tmp-userData-tests/settings.json
@@ -1,0 +1,3 @@
+{
+  "language": "en"
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "package": "electron-forge package",
     "make": "electron-forge make",
     "publish": "electron-forge publish",
-    "lint": "eslint --ext .ts,.tsx ."
+    "lint": "eslint --ext .ts,.tsx .",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "keywords": [],
   "author": {
@@ -28,15 +30,28 @@
     "@electron-forge/plugin-vite": "^7.9.0",
     "@electron/fuses": "^1.8.0",
     "@types/electron-squirrel-startup": "^1.0.2",
-    "@typescript-eslint/eslint-plugin": "^5.62.0",
-    "@typescript-eslint/parser": "^5.62.0",
+    "@types/node": "^20.16.11",
+    "@types/vue": "^1.0.31",
+    "@typescript-eslint/eslint-plugin": "^8.9.0",
+    "@typescript-eslint/parser": "^8.9.0",
+    "@vitejs/plugin-vue": "^5.1.4",
+    "@vue/test-utils": "^2.4.6",
+    "autoprefixer": "^10.4.20",
     "electron": "38.2.1",
     "eslint": "^8.57.1",
+    "eslint-import-resolver-typescript": "^3.6.3",
     "eslint-plugin-import": "^2.32.0",
-    "typescript": "~4.5.4",
-    "vite": "^5.4.20"
+    "eslint-plugin-vue": "^9.29.0",
+    "jsdom": "^27.0.0",
+    "postcss": "^8.4.47",
+    "tailwindcss": "^3.4.14",
+    "typescript": "^5.6.3",
+    "vite": "^5.4.20",
+    "vitest": "^2.1.4",
+    "vue-tsc": "^2.0.29"
   },
   "dependencies": {
-    "electron-squirrel-startup": "^1.0.1"
+    "electron-squirrel-startup": "^1.0.1",
+    "vue": "^3.5.22"
   }
 }

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,0 +1,109 @@
+<template>
+  <div class="p-4 space-y-3">
+    <div class="flex flex-wrap gap-2">
+      <button
+        class="px-3 py-1.5 bg-teal-600 text-white rounded hover:bg-teal-700"
+        @click="newFile"
+      >
+        {{ t("menu_new") }}
+      </button>
+      <button
+        class="px-3 py-1.5 bg-teal-600 text-white rounded hover:bg-teal-700"
+        @click="openFile"
+      >
+        {{ t("menu_open") }}
+      </button>
+      <button
+        class="px-3 py-1.5 bg-teal-600 text-white rounded hover:bg-teal-700"
+        @click="saveFile"
+      >
+        {{ t("menu_save") }}
+      </button>
+      <button
+        class="px-3 py-1.5 bg-teal-600 text-white rounded hover:bg-teal-700"
+        @click="saveFileAs"
+      >
+        {{ t("menu_save_as") }}
+      </button>
+      <select
+        v-model="lang"
+        class="px-2 py-1 border rounded"
+        @change="onLangChange"
+      >
+        <option value="bn">বাংলা</option>
+        <option value="en">English</option>
+      </select>
+    </div>
+    <h2 class="text-2xl font-semibold">
+      {{ appTitle }}
+    </h2>
+    <p id="status">
+      {{ status }}
+    </p>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted, computed } from "vue";
+
+const lang = ref<"bn" | "en">("bn");
+const appTitle = computed(() =>
+  lang.value === "bn" ? "এএইচবি সেলস" : "AHB Sales"
+);
+const status = ref("Ready");
+
+function t(key: string) {
+  if (lang.value === "bn") {
+    const bn: Record<string, string> = {
+      app_title: "এএইচবি সেলস",
+      menu_new: "নতুন",
+      menu_open: "ওপেন",
+      menu_save: "সেভ",
+      menu_save_as: "সেভ অ্যাজ",
+    };
+    return bn[key] ?? key;
+  }
+  const en: Record<string, string> = {
+    app_title: "AHB Sales",
+    menu_new: "New",
+    menu_open: "Open",
+    menu_save: "Save",
+    menu_save_as: "Save As",
+  };
+  return en[key] ?? key;
+}
+
+async function syncLang() {
+  const l = await window.ahb.getLanguage();
+  lang.value = l;
+}
+
+function onLangChange() {
+  window.ahb.setLanguage(lang.value);
+}
+
+function newFile() {
+  window.ahb.newFile();
+}
+function openFile() {
+  window.ahb.openFile();
+}
+function saveFile() {
+  window.ahb.saveFile();
+}
+function saveFileAs() {
+  window.ahb.saveFileAs();
+}
+
+onMounted(() => {
+  syncLang();
+  window.ahb.onLanguageChanged((l) => {
+    lang.value = l;
+  });
+  window.ahb.onDocumentChanged(() => {
+    status.value = "Document loaded/changed";
+  });
+});
+
+// Title is derived from lang via computed
+</script>

--- a/src/index.css
+++ b/src/index.css
@@ -1,8 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 body {
-  font-family:
-    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
-    sans-serif;
-  margin: auto;
-  max-width: 38rem;
-  padding: 2rem;
+  @apply max-w-3xl mx-auto p-6 font-sans;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -89,11 +89,22 @@ async function handleOpenFile() {
   });
   if (res.canceled || res.filePaths.length === 0) return;
   const filePath = res.filePaths[0];
-  const buf = fs.readFileSync(filePath);
-  const parsed = decryptJSON(buf) as AhbDocument;
-  currentDoc = parsed;
-  currentFilePath = filePath;
-  notifyAll("app:document-changed");
+  try {
+    const buf = fs.readFileSync(filePath);
+    const parsed = decryptJSON(buf) as AhbDocument;
+    currentDoc = parsed;
+    currentFilePath = filePath;
+    notifyAll("app:document-changed");
+  } catch (err) {
+    console.error("Failed to open/decrypt file:", err);
+    await dialog.showMessageBox({
+      type: "error",
+      title: "Cannot open file",
+      message:
+        "This file could not be opened. It may be corrupted, not an AHB Sales file, or encrypted with a different key.",
+      detail: `${(err as Error).message}`,
+    });
+  }
 }
 
 function writeCurrentTo(pathToWrite: string) {

--- a/src/main/crypto.ts
+++ b/src/main/crypto.ts
@@ -1,0 +1,51 @@
+import crypto from "node:crypto";
+
+// NOTE: For v1, the key is embedded at build time as per requirements.
+// In production, consider secure key management.
+// AES-256-GCM requires 32-byte key, 12-byte IV, and produces auth tag.
+
+const KEY_HEX =
+  process.env.AHB_KEY_HEX ||
+  "0000000000000000000000000000000000000000000000000000000000000000";
+const KEY = Buffer.from(KEY_HEX, "hex");
+
+export function encryptJSON(obj: unknown): Buffer {
+  const iv = crypto.randomBytes(12);
+  const cipher = crypto.createCipheriv("aes-256-gcm", KEY, iv);
+  const data = Buffer.from(JSON.stringify(obj), "utf8");
+  const enc = Buffer.concat([cipher.update(data), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  // Format: [MAGIC(4)] [VER(1)] [IV(12)] [TAG(16)] [ENC..]
+  const header = Buffer.from([0x41, 0x48, 0x42, 0x53, 0x01]); // 'AHBS' + v1
+  return Buffer.concat([header, iv, tag, enc]);
+}
+
+export function decryptJSON(buf: Buffer): unknown {
+  if (buf.length < 4 + 1 + 12 + 16) throw new Error("Invalid file");
+  const magic = buf.subarray(0, 4).toString("ascii");
+  if (magic !== "AHBS") throw new Error("Not an AHBS file");
+  const ver = buf[4];
+  if (ver !== 0x01) throw new Error(`Unsupported version: ${ver}`);
+  const iv = buf.subarray(5, 17);
+  const tag = buf.subarray(17, 33);
+  const enc = buf.subarray(33);
+  const decipher = crypto.createDecipheriv("aes-256-gcm", KEY, iv);
+  decipher.setAuthTag(tag);
+  const dec = Buffer.concat([decipher.update(enc), decipher.final()]);
+  return JSON.parse(dec.toString("utf8"));
+}
+
+export type AhbDocument = {
+  schemaVersion: number;
+  meta: { createdAt: string; updatedAt: string; branchName?: string };
+  data: unknown; // Placeholder for future schema
+};
+
+export function createEmptyDocument(): AhbDocument {
+  const now = new Date().toISOString();
+  return {
+    schemaVersion: 1,
+    meta: { createdAt: now, updatedAt: now },
+    data: {},
+  };
+}

--- a/src/main/i18n.ts
+++ b/src/main/i18n.ts
@@ -1,0 +1,63 @@
+import { app } from "electron";
+import path from "node:path";
+import fs from "node:fs";
+
+type Lang = "bn" | "en";
+
+// Simple settings persistence in userData
+const settingsPath = () => path.join(app.getPath("userData"), "settings.json");
+
+type Settings = { language: Lang };
+
+function loadSettings(): Settings {
+  try {
+    const raw = fs.readFileSync(settingsPath(), "utf8");
+    const parsed = JSON.parse(raw);
+    if (parsed && (parsed.language === "bn" || parsed.language === "en")) {
+      return { language: parsed.language };
+    }
+  } catch {
+    // ignore missing or invalid settings
+  }
+  return { language: "bn" };
+}
+
+function saveSettings(s: Settings) {
+  try {
+    fs.mkdirSync(path.dirname(settingsPath()), { recursive: true });
+    fs.writeFileSync(settingsPath(), JSON.stringify(s, null, 2), "utf8");
+  } catch {
+    // ignore write failures
+  }
+}
+
+const current = loadSettings();
+
+export function getLanguage(): Lang {
+  return current.language;
+}
+
+export function setLanguage(lang: Lang) {
+  current.language = lang;
+  saveSettings(current);
+}
+
+// Minimal dictionary example (extend later)
+export const dict: Record<Lang, Record<string, string>> = {
+  en: {
+    app_title: "AHB Sales",
+    menu_file: "File",
+    menu_new: "New",
+    menu_open: "Open",
+    menu_save: "Save",
+    menu_save_as: "Save As",
+  },
+  bn: {
+    app_title: "এএইচবি সেলস",
+    menu_file: "ফাইল",
+    menu_new: "নতুন",
+    menu_open: "ওপেন",
+    menu_save: "সেভ",
+    menu_save_as: "সেভ অ্যাজ",
+  },
+};

--- a/src/main/i18n.ts
+++ b/src/main/i18n.ts
@@ -26,8 +26,9 @@ function saveSettings(s: Settings) {
   try {
     fs.mkdirSync(path.dirname(settingsPath()), { recursive: true });
     fs.writeFileSync(settingsPath(), JSON.stringify(s, null, 2), "utf8");
-  } catch {
-    // ignore write failures
+  } catch (err) {
+    // Log failure instead of failing silently; could be enhanced to notify renderer via IPC.
+    console.error("Failed to save settings:", err);
   }
 }
 

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -1,2 +1,44 @@
 // See the Electron documentation for details on how to use preload scripts:
 // https://www.electronjs.org/docs/latest/tutorial/process-model#preload-scripts
+import { contextBridge, ipcRenderer } from "electron";
+
+type AppAPI = {
+  // File operations
+  newFile: () => Promise<void>;
+  openFile: () => Promise<void>;
+  saveFile: () => Promise<void>;
+  saveFileAs: () => Promise<void>;
+  // Language operations
+  getLanguage: () => Promise<"bn" | "en">;
+  setLanguage: (lang: "bn" | "en") => Promise<void>;
+  onLanguageChanged: (cb: (lang: "bn" | "en") => void) => () => void;
+  // Document notification
+  onDocumentChanged: (cb: () => void) => () => void;
+};
+
+const api: AppAPI = {
+  newFile: () => ipcRenderer.invoke("app:new-file"),
+  openFile: () => ipcRenderer.invoke("app:open-file"),
+  saveFile: () => ipcRenderer.invoke("app:save-file"),
+  saveFileAs: () => ipcRenderer.invoke("app:save-file-as"),
+  getLanguage: () => ipcRenderer.invoke("app:get-language"),
+  setLanguage: (lang) => ipcRenderer.invoke("app:set-language", lang),
+  onLanguageChanged: (cb) => {
+    const listener = (_: unknown, lang: "bn" | "en") => cb(lang);
+    ipcRenderer.on("app:language-changed", listener);
+    return () => ipcRenderer.removeListener("app:language-changed", listener);
+  },
+  onDocumentChanged: (cb) => {
+    const listener = () => cb();
+    ipcRenderer.on("app:document-changed", listener);
+    return () => ipcRenderer.removeListener("app:document-changed", listener);
+  },
+};
+
+declare global {
+  interface Window {
+    ahb: AppAPI;
+  }
+}
+
+contextBridge.exposeInMainWorld("ahb", api);

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -26,8 +26,10 @@
  * ```
  */
 
-import './index.css';
+import "./index.css";
+import { createApp } from "vue";
+import App from "./App.vue";
 
-console.log(
-  '👋 This message is being logged by "renderer.ts", included via Vite',
-);
+const mount = document.createElement("div");
+document.body.appendChild(mount);
+createApp(App).mount(mount);

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,12 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    "./index.html",
+    "./src/**/*.{vue,ts,tsx}",
+    "./.vite/renderer/**/*.html",
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/tests/App.spec.ts
+++ b/tests/App.spec.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { nextTick } from "vue";
+import { mount } from "@vue/test-utils";
+import App from "../src/App.vue";
+
+// Minimal SFC test ensuring component renders and language switch updates title
+
+describe("App.vue", () => {
+  it("renders and updates title on language change", async () => {
+    // Stub preload API
+    // @ts-expect-error - define test stub
+    let langCb: ((l: "bn" | "en") => void) | null = null;
+    window.ahb = {
+      getLanguage: async () => "en",
+      setLanguage: async (l: "bn" | "en") => {
+        if (langCb) {
+          langCb(l);
+        }
+      },
+      newFile: async () => Promise.resolve(),
+      openFile: async () => Promise.resolve(),
+      saveFile: async () => Promise.resolve(),
+      saveFileAs: async () => Promise.resolve(),
+      onLanguageChanged: (cb: (l: "bn" | "en") => void) => {
+        langCb = cb;
+        return () => {
+          langCb = null;
+        };
+      },
+      onDocumentChanged: (): (() => void) => {
+        return () => undefined;
+      },
+    } as unknown as Window["ahb"];
+
+    const wrapper = mount(App, { attachTo: document.body });
+    // Wait for onMounted async getLanguage to resolve and DOM to update
+    await Promise.resolve();
+    await nextTick();
+    expect(wrapper.text()).toContain("AHB Sales");
+
+    const select = wrapper.find("select");
+    await select.setValue("bn");
+    await select.trigger("change");
+    await nextTick();
+    await nextTick();
+    expect(wrapper.text()).toContain("এএইচবি সেলস");
+  });
+});

--- a/tests/crypto.test.ts
+++ b/tests/crypto.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, beforeAll } from "vitest";
+
+// Ensure a deterministic key for tests
+beforeAll(() => {
+  process.env.AHB_KEY_HEX =
+    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+});
+
+// Import after setting env so module picks it up
+import {
+  createEmptyDocument,
+  encryptJSON,
+  decryptJSON,
+  type AhbDocument,
+} from "../src/main/crypto";
+
+describe("crypto (AES-256-GCM container)", () => {
+  it("encrypts and decrypts a document roundtrip", () => {
+    const doc: AhbDocument = createEmptyDocument();
+    doc.meta.branchName = "Test Branch";
+    (doc.data as Record<string, unknown>).hello = "world";
+
+    const enc = encryptJSON(doc);
+    expect(enc.byteLength).toBeGreaterThan(4 + 1 + 12 + 16);
+
+    const dec = decryptJSON(enc) as AhbDocument;
+    expect(dec.schemaVersion).toBe(1);
+    expect(dec.meta.branchName).toBe("Test Branch");
+    expect((dec.data as Record<string, unknown>).hello).toBe("world");
+  });
+
+  it("throws on invalid magic header", () => {
+    const bad = Buffer.from("BAD!\x01" + "x".repeat(12 + 16), "binary");
+    expect(() => decryptJSON(bad)).toThrow();
+  });
+});

--- a/tests/crypto.test.ts
+++ b/tests/crypto.test.ts
@@ -1,18 +1,24 @@
 import { describe, it, expect, beforeAll } from "vitest";
 
-// Ensure a deterministic key for tests
+// TEST-ONLY: Set a deterministic encryption key for unit tests.
+// DO NOT use this key in production builds.
 beforeAll(() => {
   process.env.AHB_KEY_HEX =
     "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 });
 
 // Import after setting env so module picks it up
-import {
-  createEmptyDocument,
-  encryptJSON,
-  decryptJSON,
-  type AhbDocument,
-} from "../src/main/crypto";
+let createEmptyDocument: (typeof import("../src/main/crypto"))["createEmptyDocument"];
+let encryptJSON: (typeof import("../src/main/crypto"))["encryptJSON"];
+let decryptJSON: (typeof import("../src/main/crypto"))["decryptJSON"];
+type AhbDocument = import("../src/main/crypto").AhbDocument;
+
+beforeAll(async () => {
+  const mod = await import("../src/main/crypto");
+  createEmptyDocument = mod.createEmptyDocument;
+  encryptJSON = mod.encryptJSON;
+  decryptJSON = mod.decryptJSON;
+});
 
 describe("crypto (AES-256-GCM container)", () => {
   it("encrypts and decrypts a document roundtrip", () => {

--- a/tests/i18n.test.ts
+++ b/tests/i18n.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("electron", () => {
+  const fakeApp = {
+    getPath: (key: string) => {
+      if (key === "userData") return process.cwd() + "/.tmp-userData-tests";
+      return process.cwd();
+    },
+  };
+  return { app: fakeApp };
+});
+
+import fs from "node:fs";
+import path from "node:path";
+
+let getLanguage: typeof import("../src/main/i18n").getLanguage;
+let setLanguage: typeof import("../src/main/i18n").setLanguage;
+
+const settingsPath = path.join(
+  process.cwd(),
+  ".tmp-userData-tests",
+  "settings.json"
+);
+
+describe("i18n settings persistence", () => {
+  beforeEach(async () => {
+    try {
+      fs.rmSync(path.dirname(settingsPath), { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+    // Reset module cache to re-evaluate default
+    vi.resetModules();
+    const mod = await import("../src/main/i18n");
+    getLanguage = mod.getLanguage;
+    setLanguage = mod.setLanguage;
+  });
+
+  it("defaults to Bengali when no settings exist", () => {
+    expect(getLanguage()).toBe("bn");
+  });
+
+  it("persists chosen language", () => {
+    setLanguage("en");
+    expect(getLanguage()).toBe("en");
+    const raw = fs.readFileSync(settingsPath, "utf8");
+    expect(raw.includes('"language": "en"')).toBe(true);
+  });
+});

--- a/vite.renderer.config.ts
+++ b/vite.renderer.config.ts
@@ -1,4 +1,7 @@
-import { defineConfig } from 'vite';
+import { defineConfig } from "vite";
+import vue from "@vitejs/plugin-vue";
 
 // https://vitejs.dev/config
-export default defineConfig({});
+export default defineConfig({
+  plugins: [vue()],
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vitest/config";
+import vue from "@vitejs/plugin-vue";
+
+export default defineConfig({
+  plugins: [vue()],
+  test: {
+    environment: "jsdom",
+    include: ["tests/**/*.{test,spec}.ts"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html"],
+    },
+  },
+});


### PR DESCRIPTION
This pull request introduces a significant set of changes to migrate the Electron app to a Vue 3 + TypeScript frontend, add file encryption/decryption, implement language (i18n) support with persistence, and establish a modern development workflow with Tailwind CSS and Vitest for testing. The changes include updates to build and linting configs, new core application logic for file and language management, and comprehensive tests.

The most important changes are:

**Frontend Migration to Vue 3 + Tailwind CSS:**
* Migrated the renderer to Vue 3 by adding `src/App.vue` as the main UI component, updating `src/renderer.ts` to mount the Vue app, and integrating Tailwind CSS for styling (`src/index.css`, `postcss.config.cjs`). [[1]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0R1-R109) [[2]](diffhunk://#diff-feb7ceb6e19ece5ccb87c867d2c740d1cd0669de790815c5d1107259c0fc0212L29-R35) [[3]](diffhunk://#diff-85da366246340e911d7a0eb9153e64137a1b31f0686c74d9aef9ae4f032cb09eR1-R6) [[4]](diffhunk://#diff-8359bb716171c7a71348ef352134d5f6dcad444956e4e0362e5e61e6856edecaR1-R6)
* Updated ESLint and Vite configurations to support Vue SFCs, TypeScript, and Tailwind (`.eslintrc.json`, `vite.renderer.config.ts`, `package.json`). [[1]](diffhunk://#diff-6884918dc8291219be508e05e28965b958c734def85324f3b53858ea4702090fL13-R38) [[2]](diffhunk://#diff-fe372c44570e4c8f3bc21566f850113f849b912635a5d80b219bca6ce33fc779L1-R7) [[3]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L12-R14) [[4]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L31-R55)

**File Encryption and Document Management:**
* Implemented AES-256-GCM encrypted file storage for app documents, including new helpers for encrypting/decrypting JSON and managing document schema (`src/main/crypto.ts`).
* Added main process logic for creating, opening, saving, and saving-as encrypted documents, with IPC wiring to the renderer (`src/main.ts`). [[1]](diffhunk://#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3dL1-R11) [[2]](diffhunk://#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3dR65-R135)

**Language (i18n) Support with Persistence:**
* Added persistent language selection using a simple JSON settings file, with main process helpers and dictionary (`src/main/i18n.ts`, `.tmp-userData-tests/settings.json`). [[1]](diffhunk://#diff-46e28d79d72de88843beb26d44d363504e1ebe76da59df8149f588500908dc19R1-R63) [[2]](diffhunk://#diff-2ab2a596207b29bbc9d23b409d9497e6fd26de8c9907651238177d26ba5c657bR1-R3)
* Exposed language operations and document change notifications to the renderer via a secure preload bridge (`src/preload.ts`).
* Updated the Vue app to allow switching between Bengali and English, reflecting changes in the UI (`src/App.vue`).

**Testing Infrastructure:**
* Integrated Vitest and Vue Test Utils for unit/component testing, including tests for the Vue app, crypto logic, and i18n persistence (`tests/App.spec.ts`, `tests/crypto.test.ts`, `tests/i18n.test.ts`). [[1]](diffhunk://#diff-1a42b03111ff13fee8bf2846f9ec38d60cec50e40f03af44d52a2b49cf150578R1-R48) [[2]](diffhunk://#diff-82c918d0f37cf020bade0dc05973fb53bf319b4c07d24b5039fc7cdca902cedaR1-R36) [[3]](diffhunk://#diff-f9ec3e39a221d46725a6b3f665aebaaab347ae7411748b193890dd5b3a93e4c7R1-R49)
* Added test scripts to `package.json` for running and watching tests.

These changes collectively modernize the app's architecture, improve security and usability, and establish a foundation for further feature development.… file operations, and encryption